### PR TITLE
activemodel・activesupportのバージョンアップデート

### DIFF
--- a/idcf-faraday_middleware.gemspec
+++ b/idcf-faraday_middleware.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '>= 4.2'
-  spec.add_runtime_dependency 'activemodel', '>= 4.2'
+  spec.add_runtime_dependency 'activemodel', '~> 5.2', '>= 5.2.4'
+  spec.add_runtime_dependency 'activesupport', '~> 5.2', '>= 5.2.4'
   spec.add_runtime_dependency 'faraday'
   spec.add_runtime_dependency 'faraday_middleware'
 

--- a/idcf-faraday_middleware.gemspec
+++ b/idcf-faraday_middleware.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'awesome_print'
+  spec.add_development_dependency 'coveralls'
 
   spec.required_ruby_version = '>= 1.9.3'
 end

--- a/lib/idcf/faraday_middleware/version.rb
+++ b/lib/idcf/faraday_middleware/version.rb
@@ -1,5 +1,5 @@
 module Idcf
   module FaradayMiddleware
-    VERSION = '0.0.2'.freeze
+    VERSION = '0.0.3'.freeze
   end
 end


### PR DESCRIPTION
## 概要

Fix idcf-private/issues#2416

`idcf-internal/idcfcloud-cli` の activesupportのバージョンを上げる必要が出たが、依存にこのライブラリがあったのでまずこちらのactivesupport(activemodel)のバージョンを上げた。

##  関連しているPR

https://github.com/idcf-internal/idcfcloud-cli/pull/29

このPRがマージされ、リリースしたら上記ライブラリの依存を更新する必要があります。

## 参考

こちらの記事を参考にruby2.7系でワーニングが出ないバージョンまで上げたつもりである。
https://tech.recruit-mp.co.jp/server-side/post-19932/

## レビュワーへ

- [ ] コードレビューをお願いします。