### PR TITLE
シグネチャ算出に使うexpiresをヘッダに付与するものと同じにする

### DIFF
--- a/idcf-faraday_middleware.gemspec
+++ b/idcf-faraday_middleware.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'awesome_print'
+  spec.add_development_dependency 'coveralls'
 
   spec.required_ruby_version = '>= 1.9.3'
 end

--- a/lib/idcf/faraday_middleware/cdn_signature.rb
+++ b/lib/idcf/faraday_middleware/cdn_signature.rb
@@ -28,7 +28,7 @@ module Idcf
           env.method.to_s.upcase,
           api_key,
           secret_key,
-          expires,
+          env[:request_headers][EXPIRES],
           env.url.request_uri,
           env.body.to_s
         ].join("\n")

--- a/lib/idcf/faraday_middleware/signature.rb
+++ b/lib/idcf/faraday_middleware/signature.rb
@@ -40,7 +40,7 @@ module Idcf
           env.method.to_s.upcase,
           env.url.path,
           api_key,
-          expires,
+          env[:request_headers][HEADER_EXPIRES],
           env.url.query.to_s.gsub('+', '%20')
         ].join("\n")
       end

--- a/lib/idcf/faraday_middleware/version.rb
+++ b/lib/idcf/faraday_middleware/version.rb
@@ -1,5 +1,5 @@
 module Idcf
   module FaradayMiddleware
-    VERSION = '0.0.2'.freeze
+    VERSION = '0.0.3'.freeze
   end
 end

--- a/spec/idcf/faraday_middleware_spec.rb
+++ b/spec/idcf/faraday_middleware_spec.rb
@@ -5,75 +5,36 @@ RSpec.describe Idcf::FaradayMiddleware do
     expect(Idcf::FaradayMiddleware::VERSION).not_to be nil
   end
 
-  describe Idcf::FaradayMiddleware::Signature do
-    class DummyApp
-      def initialize(secret_key)
-        @secret_key = secret_key
-      end
+  let(:random_source) { (('A'..'Z').to_a + ('a'..'z').to_a + (0..9).to_a + ['-', '_']) }
+  let(:api_key) { value = ""; 86.times { value += random_source.sample(1)[0].to_s; }; value; }
+  let(:secret_key) { value = ""; 86.times { value += random_source.sample(1)[0].to_s; }; value; }
 
-      def call env
-        env
+  shared_examples "100000_times" do
+    specify do
+      try = 100000
+      cnt = 0
+      try.times do |idx|
+        env = subject.call(app.create_env)
+        break unless app.check(env)
+        cnt = idx + 1
       end
-
-      def check env
-        @api_key = env[:request_headers][Idcf::FaradayMiddleware::Configuration::HEADER_API_KEY]
-        @expires = env[:request_headers][Idcf::FaradayMiddleware::Configuration::HEADER_EXPIRES]
-        env[:request_headers][Idcf::FaradayMiddleware::Configuration::HEADER_SIGNATURE] == signature(create_env)
-      end
-
-      class DummyEnv < OpenStruct
-        def method
-          "method"
-        end
-      end
-
-      def create_env
-        env = DummyEnv.new(url: OpenStruct.new(path: "path", query: "query"), request_headers: {})
-      end
-
-      private
-
-      def signature env
-        Base64.strict_encode64(
-          OpenSSL::HMAC.digest(
-            OpenSSL::Digest::SHA256.new,
-            @secret_key,
-            signature_seed(env)
-          )
-        )
-      end
-
-      def signature_seed env
-        [
-          env.method.to_s.upcase,
-          env.url.path,
-          @api_key,
-          @expires,
-          env.url.query.to_s.gsub('+', '%20')
-        ].join("\n")
-      end
+      expect(cnt).to eq(try)
     end
+  end
 
-    let(:random_source) { (('A'..'Z').to_a + ('a'..'z').to_a + (0..9).to_a + ['-', '_']) }
-    let(:api_key) { value = ""; 86.times { value += random_source.sample(1)[0].to_s; }; value; }
-    let(:secret_key) { value = ""; 86.times { value += random_source.sample(1)[0].to_s; }; value; }
-    let(:app) { DummyApp.new secret_key }
-
+  describe Idcf::FaradayMiddleware::Signature do
+    let(:app) { DummyAppSignature.new api_key, secret_key }
     subject { described_class.new app, api_key: api_key, secret_key: secret_key }
-
     describe "#call" do
-      context "10000 times" do
-        specify do
-          try = 100000
-          cnt = 0
-          try.times do |idx|
-            env = subject.call(app.create_env)
-            break unless app.check(env)
-            cnt = idx + 1
-          end
-          expect(cnt).to eq(try)
-        end
-      end
+      it_behaves_like "100000_times"
+    end
+  end
+
+  describe Idcf::FaradayMiddleware::CdnSignature do
+    let(:app) { DummyAppCdnSignature.new api_key, secret_key }
+    subject { described_class.new app, api_key: api_key, secret_key: secret_key }
+    describe "#call" do
+      it_behaves_like "100000_times"
     end
   end
 end

--- a/spec/idcf/faraday_middleware_spec.rb
+++ b/spec/idcf/faraday_middleware_spec.rb
@@ -5,7 +5,75 @@ RSpec.describe Idcf::FaradayMiddleware do
     expect(Idcf::FaradayMiddleware::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  describe Idcf::FaradayMiddleware::Signature do
+    class DummyApp
+      def initialize(secret_key)
+        @secret_key = secret_key
+      end
+
+      def call env
+        env
+      end
+
+      def check env
+        @api_key = env[:request_headers][Idcf::FaradayMiddleware::Configuration::HEADER_API_KEY]
+        @expires = env[:request_headers][Idcf::FaradayMiddleware::Configuration::HEADER_EXPIRES]
+        env[:request_headers][Idcf::FaradayMiddleware::Configuration::HEADER_SIGNATURE] == signature(create_env)
+      end
+
+      class DummyEnv < OpenStruct
+        def method
+          "method"
+        end
+      end
+
+      def create_env
+        env = DummyEnv.new(url: OpenStruct.new(path: "path", query: "query"), request_headers: {})
+      end
+
+      private
+
+      def signature env
+        Base64.strict_encode64(
+          OpenSSL::HMAC.digest(
+            OpenSSL::Digest::SHA256.new,
+            @secret_key,
+            signature_seed(env)
+          )
+        )
+      end
+
+      def signature_seed env
+        [
+          env.method.to_s.upcase,
+          env.url.path,
+          @api_key,
+          @expires,
+          env.url.query.to_s.gsub('+', '%20')
+        ].join("\n")
+      end
+    end
+
+    let(:random_source) { (('A'..'Z').to_a + ('a'..'z').to_a + (0..9).to_a + ['-', '_']) }
+    let(:api_key) { value = ""; 86.times { value += random_source.sample(1)[0].to_s; }; value; }
+    let(:secret_key) { value = ""; 86.times { value += random_source.sample(1)[0].to_s; }; value; }
+    let(:app) { DummyApp.new secret_key }
+
+    subject { described_class.new app, api_key: api_key, secret_key: secret_key }
+
+    describe "#call" do
+      context "10000 times" do
+        specify do
+          try = 100000
+          cnt = 0
+          try.times do |idx|
+            env = subject.call(app.create_env)
+            break unless app.check(env)
+            cnt = idx + 1
+          end
+          expect(cnt).to eq(try)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
ヘッダに付与する`expires`とシグネチャ生成に使用する`expires`でタイミングによってずれが生じ、結果サーバー側でシグネチャ不一致エラーが発生することがある。
その修正。